### PR TITLE
Allow devDependencies to include >=0.4.1 for grunt.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.1"
+      "grunt": ">=0.4.1"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"


### PR DESCRIPTION
This lets other packages include this with grunt >=1 which ~0.4.1
didn't allow. peerDependencies had been updated in the past, but devDependencies was still forcing an earlier version of grunt.